### PR TITLE
[training#1] add catalog ls task definition and parser

### DIFF
--- a/lib/jobs/ucs-catalog.js
+++ b/lib/jobs/ucs-catalog.js
@@ -49,6 +49,10 @@ function UcsCatalogJobFactory(
             this.nodes = [ this.context.target ];
         }
         this.ucs = new UcsTool();
+        this.boardChildrenToExtend = [
+            //"disk-collection",
+            "memarray-collection"
+        ];
     }
 
     util.inherits(UcsCatalogJob, BaseJob);
@@ -69,6 +73,12 @@ function UcsCatalogJobFactory(
         });
     };
 
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {String} dn: distinguished name of ucs managed object
+     * @param {Boolean} withSelfData: boolean value to indicate if to include self data of dn
+     * @return {Object}: JSON data got from ucs service
+     */
     UcsCatalogJob.prototype._getDataByDN = function (dn, withSelfData) {
         var self = this;
         var groupingPattern = /^(.*)-\d{1,2}$/;
@@ -86,12 +96,12 @@ function UcsCatalogJobFactory(
                 if(!withSelfData) {
                     return;
                 } else {
-                    result[data.rn] = data; 
+                    result[data.rn] = data;
                 }
             } else {
                 if(matched) {
                     var name = matched[1] + "-collection";
-                    result[name] = result[name] || [];  
+                    result[name] = result[name] || [];
                     result[name].push(data);
                 } else {
                     result[data.rn] = data;
@@ -104,54 +114,100 @@ function UcsCatalogJobFactory(
     };
 
     /**
-     * @function Catalog Servers
-     * @description Catalog all the servers in the Cisco UCS
+     * @memberOf UcsCatalogJob
+     * @param {Object | arrayOfObject} collection: board children object data
+     * @return {Object}: JSON data got from ucs service
+     */
+    UcsCatalogJob.prototype._extendBoardChildCatalog = function(collection) {
+        var self = this;
+        var _collection;
+        if (!_.isArray(collection)) {
+            _collection = [collection];
+        } else {
+            _collection = collection;
+        }
+        return Promise.map(_collection, function(item) {
+            return self._getDataByDN(item.dn)
+            .then(function(result) {
+                item.children = result;
+            });
+        });
+    };
+
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {Object} board: board object data
+     * @return {Promise}
+     */
+    UcsCatalogJob.prototype._extendBoardCatalog = function(board) {
+        var self = this;
+        var extendPromiseList = [];
+        var boardKeys = _.keys(board);
+        return Promise.try(function(){
+            var boardChildrenToExtend = _.cloneDeep(self.boardChildrenToExtend);
+            _.forEach(boardKeys, function(key){
+                if (_.startsWith(key, "storage-")) {
+                    boardChildrenToExtend.push(key);
+                }
+            });
+            _.forEach(boardChildrenToExtend, function(boardChild){
+                var boardChildData = board[boardChild];
+                extendPromiseList.push(self._extendBoardChildCatalog(boardChildData));
+            });
+            return Promise.all(extendPromiseList);
+        });
+    };
+
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {string} nodeId: node ID
+     * @return {Promise}
      */
     UcsCatalogJob.prototype.catalogServers = function(nodeId) {
         var self = this;
         var nodeName = '';
         return self.ucs.setup(nodeId)
-            .then(function(){
-                return waterline.nodes.getNodeById(nodeId);
-            })
-            .then(function(node){
-                nodeName = node.name;
-                return Promise.all([self._getDataByDN(nodeName, true), self._getDataByDN(nodeName + '/board')])
-                .spread(function(nodeResult, boardResult) {
-                    if(nodeResult.board) {
-                        nodeResult.board.children = boardResult;
-                        return Promise.map(boardResult['memarray-collection'], function(memarray) {
-                            return self._getDataByDN(memarray.dn)
-                            .then(function(memoryResult) {
-                                memarray.children = memoryResult;
-                            }); 
-                        })
-                        .then(function() {
-                            return nodeResult;
-                        });
-                    }  
-                    return nodeResult;
-                });
-            })
-            .then(function(data) {
-                return _.map(data, function(value, key) {
-                    return waterline.catalogs.create({
-                        node: nodeId,
-                        source: (value.dn === nodeName) ? 'UCS' : 'UCS:' + key,
-                        data: value
+        .then(function(){
+            return waterline.nodes.getNodeById(nodeId);
+        })
+        .then(function(node){
+            nodeName = node.name;
+            return Promise.all([
+                self._getDataByDN(nodeName, true),
+                self._getDataByDN(nodeName + '/board')
+            ])
+            .spread(function(nodeResult, boardResult) {
+                if(nodeResult.board) {
+                    // Get more details under rn="board" as hardware info like memory,
+                    // disk, cpu are under rn="board"
+                    nodeResult.board.children = boardResult;
+                    return self._extendBoardCatalog(boardResult)
+                    .then(function() {
+                        return nodeResult;
                     });
-                });
-            })
-            .all(function() {
-                return nodeId;
-            })
-            .catch(function(err) {
-                logger.error('Ucs Servers', { error:err });
-                if(err.message !== 'No Servers Members') {
-                    throw err;
                 }
-                return nodeId; // allow
+                return nodeResult;
             });
+        })
+        .then(function(data) {
+            return _.map(data, function(value, key) {
+                return waterline.catalogs.create({
+                    node: nodeId,
+                    source: (value.dn === nodeName) ? 'UCS' : 'UCS:' + key,
+                    data: value
+                });
+            });
+        })
+        .all(function() {
+            return nodeId;
+        })
+        .catch(function(err) {
+            logger.error('Ucs Servers', { error:err });
+            if(err.message !== 'No Servers Members') {
+                throw err;
+            }
+            return nodeId; // allow
+        });
     };
     return UcsCatalogJob;
 }

--- a/lib/task-data/tasks/catalog-ls.js
+++ b/lib/task-data/tasks/catalog-ls.js
@@ -1,0 +1,19 @@
+// Copyright 2017, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Catalog ls',
+    injectableName: 'Task.Catalog.ls',
+    implementsTask: 'Task.Base.Linux.Catalog',
+    options: {
+        commands: [
+            'sudo ls -l /var'
+        ]
+    },
+    properties: {
+        catalog: {
+            type: 'ls'
+        }
+    }
+};

--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -43,7 +43,8 @@ function commandParserFactory(Logger, Promise, _) {
         smart = 'sudo bash get_smart.sh',
         driveid = 'sudo node get_driveid.js',
         lldp = 'sudo /usr/sbin/lldpcli show neighbor -f keyvalue',
-        ip = 'sudo ip -d addr show; sudo ip -d link show';
+        ip = 'sudo ip -d addr show; sudo ip -d link show',
+        ls = 'sudo ls -l /var';
 
     var matchParsers = {};
     matchParsers.esxcliNetworkDriverVersion = {
@@ -1172,6 +1173,52 @@ function commandParserFactory(Logger, Promise, _) {
             return Promise.resolve({ data: parsed, source: 'ip', lookups: lookups, store: true });
         } catch (e) {
             return Promise.resolve({ source: 'ip', error: e });
+        }
+    };
+
+    CommandParser.prototype[ls] = function(data) {
+        if (data.error) {
+            return Promise.resolve({ source: 'ls', error: data.error });
+        }
+        try {
+            var lines = data.stdout.split("\n");
+            var parsed = _.transform(lines, function(result, line) {
+                if (!line) {
+                    return false;
+                }
+                else if (!line.startsWith('total')) {
+                    var s = line.split(" ").filter(Boolean);
+                    var item = {};
+                    if (s[0][0] === 'd') {
+                        item.file_type = "directory";
+                    } else if (s[0][0] === 'l'){
+                        item.file_type = "link";
+                    } else {
+                        item.file_type = "file";
+                    }
+
+                    var permission = {
+                        "user": s[0].substr(1,3),
+                        "group": s[0].substr(4,3),
+                        "others": s[0].substr(7,3),
+                    };
+                    item.permission = permission;
+
+                    item.link_count = s[1];
+                    item.owner = s[2];
+                    item.group = s[3];
+                    item.size = s[4];
+                    item.modifiedtime = s[5]+" "+s[6]+" "+s[7];
+                    item.name =  s[8];
+                    if (s[10] !== undefined) {
+                        item.link_origin = s[10];
+                    }
+                    result.push(item);
+                }
+            }, []);
+            return Promise.resolve({ data: parsed, source: 'ls', store: true });
+        } catch(e) {
+            return Promise.reject({ source: 'ls', error: e });
         }
     };
 

--- a/spec/lib/utils/job-utils/samplefiles/ucs-catalog-sample.txt
+++ b/spec/lib/utils/job-utils/samplefiles/ucs-catalog-sample.txt
@@ -1,4 +1,16 @@
 {
+  "storage-flexflash-1": [
+    {
+        "dn": "sys/rack-unit-2/board/storage-flexflash-1/disk-8",
+        "rn": "disk-8",
+        "serial": "RKDISK388"
+    },
+    {
+        "dn": "sys/rack-unit-2/board/storage-flexflash-1/disk-7",
+        "rn": "disk-7",
+        "serial": "RKDISK387"
+    }
+  ],
   "memarray-1": [
     {
       "width": "64",


### PR DESCRIPTION
## Background
Training#1: Design a Linux catalog task which parse the ls -l /var and store the result into source ls.

## Related PR:
https://github.com/iceiilin/on-taskgraph/pull/1

## Implementation:
add task definition and command parser for catalog ls task

## Result:
After node discovery, a "ls" catalog source is shown as below:
```
onrack@lyne-env:~$ http :8080/api/2.0/nodes/59acfc42fb8955313565944b/catalogs/ls
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 2256
Content-Type: application/json; charset=utf-8
Date: Mon, 04 Sep 2017 07:14:58 GMT
ETag: W/"8d0-o2+9cR5kqs5430MBQB2PN97lCdY"
X-Powered-By: Express

{
    "createdAt": "2017-09-04T07:12:20.813Z",
    "data": [
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "2",
            "modifiedtime": "Apr 10 2014",
            "name": "backups",
            "owner": "root",
            "permission": {
                "group": "r-x",
                "others": "r-x",
                "user": "rwx"
            },
            "size": "3"
        },
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "1",
            "modifiedtime": "Sep 4 07:11",
            "name": "cache",
            "owner": "root",
            "permission": {
                "group": "r-x",
                "others": "r-x",
                "user": "rwx"
            },
            "size": "100"
        },
...
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "2",
            "modifiedtime": "Jun 21 00:23",
            "name": "tmp",
            "owner": "root",
            "permission": {
                "group": "rwx",
                "others": "rwt",
                "user": "rwx"
            },
            "size": "3"
        }
    ],
    "id": "734f37ac-34bc-4b77-9d1e-35df396944a1",
    "node": "59acfc42fb8955313565944b",
    "source": "ls",
    "updatedAt": "2017-09-04T07:12:20.813Z"
}
```
