### PR TITLE
[training#1] add catalog ls task into node discovery graph

### DIFF
--- a/lib/task-data/tasks/catalog-ls.js
+++ b/lib/task-data/tasks/catalog-ls.js
@@ -1,0 +1,19 @@
+// Copyright 2017, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Catalog ls',
+    injectableName: 'Task.Catalog.ls',
+    implementsTask: 'Task.Base.Linux.Catalog',
+    options: {
+        commands: [
+            'sudo ls -l /var'
+        ]
+    },
+    properties: {
+        catalog: {
+            type: 'ls'
+        }
+    }
+};

--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -43,7 +43,8 @@ function commandParserFactory(Logger, Promise, _) {
         smart = 'sudo bash get_smart.sh',
         driveid = 'sudo node get_driveid.js',
         lldp = 'sudo /usr/sbin/lldpcli show neighbor -f keyvalue',
-        ip = 'sudo ip -d addr show; sudo ip -d link show';
+        ip = 'sudo ip -d addr show; sudo ip -d link show',
+        ls = 'sudo ls -l /var';
 
     var matchParsers = {};
     matchParsers.esxcliNetworkDriverVersion = {
@@ -1172,6 +1173,52 @@ function commandParserFactory(Logger, Promise, _) {
             return Promise.resolve({ data: parsed, source: 'ip', lookups: lookups, store: true });
         } catch (e) {
             return Promise.resolve({ source: 'ip', error: e });
+        }
+    };
+
+    CommandParser.prototype[ls] = function(data) {
+        if (data.error) {
+            return Promise.resolve({ source: 'ls', error: data.error });
+        }
+        try {
+            var lines = data.stdout.split("\n");
+            var parsed = _.transform(lines, function(result, line) {
+                if (!line) {
+                    return false;
+                }
+                else if (!line.startsWith('total')) {
+                    var s = line.split(" ").filter(Boolean);
+                    var item = {};
+                    if (s[0][0] === 'd') {
+                        item.file_type = "directory";
+                    } else if (s[0][0] === 'l'){
+                        item.file_type = "link";
+                    } else {
+                        item.file_type = "file";
+                    }
+
+                    var permission = {
+                        "user": s[0].substr(1,3),
+                        "group": s[0].substr(4,3),
+                        "others": s[0].substr(7,3),
+                    };
+                    item.permission = permission;
+
+                    item.link_count = s[1];
+                    item.owner = s[2];
+                    item.group = s[3];
+                    item.size = s[4];
+                    item.modifiedtime = s[5]+" "+s[6]+" "+s[7];
+                    item.name =  s[8];
+                    if (s[10] !== undefined) {
+                        item.link_origin = s[10];
+                    }
+                    result.push(item);
+                }
+            }, []);
+            return Promise.resolve({ data: parsed, source: 'ls', store: true });
+        } catch(e) {
+            return Promise.reject({ source: 'ls', error: e });
         }
     };
 


### PR DESCRIPTION
## Background
Training#1: Design a Linux catalog task which parse the ls -l /var and store the result into source ls.

## Related PR:
https://github.com/iceiilin/on-taskgraph/pull/2

## Implementation:
add task definition and command parser for catalog ls task

## Result:
After node discovery, a "ls" catalog source is shown as below:
```
onrack@lyne-env:~$ http :8080/api/2.0/nodes/59acfc42fb8955313565944b/catalogs/ls
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 2256
Content-Type: application/json; charset=utf-8
Date: Mon, 04 Sep 2017 07:14:58 GMT
ETag: W/"8d0-o2+9cR5kqs5430MBQB2PN97lCdY"
X-Powered-By: Express

{
    "createdAt": "2017-09-04T07:12:20.813Z",
    "data": [
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "2",
            "modifiedtime": "Apr 10 2014",
            "name": "backups",
            "owner": "root",
            "permission": {
                "group": "r-x",
                "others": "r-x",
                "user": "rwx"
            },
            "size": "3"
        },
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "1",
            "modifiedtime": "Sep 4 07:11",
            "name": "cache",
            "owner": "root",
            "permission": {
                "group": "r-x",
                "others": "r-x",
                "user": "rwx"
            },
            "size": "100"
        },
...
        {
            "file_type": "directory",
            "group": "root",
            "link_count": "2",
            "modifiedtime": "Jun 21 00:23",
            "name": "tmp",
            "owner": "root",
            "permission": {
                "group": "rwx",
                "others": "rwt",
                "user": "rwx"
            },
            "size": "3"
        }
    ],
    "id": "734f37ac-34bc-4b77-9d1e-35df396944a1",
    "node": "59acfc42fb8955313565944b",
    "source": "ls",
    "updatedAt": "2017-09-04T07:12:20.813Z"
}
```
