### PR TITLE
[training#2] add ipmi powerStatus poller and status alert job

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -77,6 +77,9 @@ function ipmiJobFactory(
                 self.createCallback('chassis', self.collectIpmiChassis.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'driveHealth',
                 self.createCallback('driveHealth', self.collectIpmiDriveHealth.bind(self)));
+            self._subscribeRunIpmiCommand(self.routingKey, 'powerStatus',
+                self.createCallback('powerStatus', self.collectIpmiPowerStatus.bind(self)));
+
         })
         .catch(function(err) {
             logger.error("Failed to initialize job", { error:err });
@@ -100,7 +103,8 @@ function ipmiJobFactory(
                 sel: 0,
                 chassis: 0,
                 driveHealth: 0,
-                selEntries: 0
+                selEntries: 0,
+                powerStatus: 0
             };
         }
         if (this.concurrent[host][type] > 0) {
@@ -465,5 +469,19 @@ function ipmiJobFactory(
         });
     };
 
+    /**
+     * Collect drive health status data from IPMI
+     * @memberOf IpmiJob
+     *
+     * @param data
+     */
+    IpmiJob.prototype.collectIpmiPowerStatus = function(data) {
+        return ipmitool.powerStatus(data.host, data.user, data.password)
+        .then(function (status) {
+            return { 'status': status.indexOf('is on') > -1 ? 'ON' : 'OFF' };
+        });
+    };
+
     return IpmiJob;
+
 }

--- a/lib/jobs/message-cache-job.js
+++ b/lib/jobs/message-cache-job.js
@@ -90,7 +90,8 @@ function pollerMessageCacheJobFactory(
                    'sel', 
                    'selEntries', 
                    'chassis', 
-                   'driveHealth'], 
+                   'driveHealth',
+                   'powerStatus'],
             function(command) {
             self._subscribeIpmiCommandResult(
                 self.routingKey,


### PR DESCRIPTION
## Background
Training#2-1: add ipmi powerStatus poller.

## Implementation:
add powerStatus poller callback in ipmi-job and corresponding item in message-cache

## Result:
After posting powerStatus poller using the following command:
```
 curl -X POST -H 'Content-Type: application/json' -d '{"type":"ipmi","pollInterval":10000,"node":"59ad08886cea19993a4c7a77", "config":{"command":"powerStatus"}}' localhost:8080/api/2.0/pollers
```

The powerStatus poller data is shown as below:
```
curl localhost:8080/api/2.0/pollers/59ad13a5a8455cbf3eafd5f9/data/current | python -mjson.tool
[
    {
        "host": "172.31.128.21",
        "node": "59ad08886cea19993a4c7a77",
        "powerStatus": {
            "status": "OFF"
        },
        "timestamp": "Mon Sep 04 2017 09:01:21 GMT+0000 (UTC)",
        "user": "admin"
    }
]
```
After powering on the node, and wait for 10s,
```
ipmitool -I lanplus -U admin -P admin -H 172.31.128.21 chassis power on
```
The poller data is
```
[
    {
        "host": "172.31.128.21",
        "node": "59ad08886cea19993a4c7a77",
        "powerStatus": {
            "status": "ON"
        },
        "timestamp": "Mon Sep 04 2017 09:17:29 GMT+0000 (UTC)",
        "user": "admin"
    }
]
```